### PR TITLE
Epic 2: Channel Management

### DIFF
--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -168,17 +168,28 @@
 - [x] Returns proper JSON structure for each channel
 - [x] Handles default pagination parameters
 
-### Story 2.5: Get Customer Channels
+### Story 2.5: Get Customer Channels ✅ **COMPLETED**
 **As a** client application  
 **I want to** get all channels for a specific customer  
 **So that** I can show their conversation list  
 
 **Acceptance Criteria:**
-- [ ] GET `/api/v1/channels/customer/{customer_uuid}` endpoint exists
-- [ ] Returns channels where customer participates
-- [ ] Only returns channels for authenticated client
-- [ ] Returns 404 for non-existent customer
-- [ ] Returns 404 for customer from different client
+- [x] GET `/api/v1/channels/customer/{customer_uuid}` endpoint exists
+- [x] Returns channels where customer participates
+- [x] Only returns channels for authenticated client
+- [x] Returns 404 for non-existent customer
+- [x] Returns 404 for customer from different client
+
+**Test Cases:**
+- [x] Can get channels for a specific customer
+- [x] Only returns channels for authenticated client
+- [x] Returns 404 for non-existent customer
+- [x] Returns 404 for customer from different client
+- [x] Returns empty list when customer has no channels
+- [x] Requires authentication
+- [x] Requires public key header
+- [x] Validates origin domain
+- [x] Returns proper JSON structure for each channel
 
 ## Epic 3: Message Management
 

--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -144,17 +144,29 @@
 - [x] Can retrieve custom channel
 - [x] Returns proper JSON structure
 
-### Story 2.4: List Channels
+### Story 2.4: List Channels ✅ **COMPLETED**
 **As a** client application  
 **I want to** list all channels for my client  
 **So that** I can manage conversations  
 
 **Acceptance Criteria:**
-- [ ] GET `/api/v1/channels` endpoint exists
-- [ ] Returns paginated list of channels
-- [ ] Only returns channels for authenticated client
-- [ ] Supports pagination parameters
-- [ ] Returns total count
+- [x] GET `/api/v1/channels` endpoint exists
+- [x] Returns paginated list of channels
+- [x] Only returns channels for authenticated client
+- [x] Supports pagination parameters
+- [x] Returns total count
+
+**Test Cases:**
+- [x] Can list channels for authenticated client
+- [x] Only returns channels for authenticated client
+- [x] Supports pagination parameters
+- [x] Supports cursor-based pagination with starting_after
+- [x] Returns empty list when no channels exist
+- [x] Requires authentication
+- [x] Requires public key header
+- [x] Validates origin domain
+- [x] Returns proper JSON structure for each channel
+- [x] Handles default pagination parameters
 
 ### Story 2.5: Get Customer Channels
 **As a** client application  

--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -122,17 +122,27 @@
 - [ ] Rejects if customers belong to different clients
 - [ ] Requires authentication
 
-### Story 2.3: Retrieve Channel
-**As a** client application  
-**I want to** retrieve channel information  
-**So that** I can display channel details  
+### Story 2.3: Retrieve Channel ✅ **COMPLETED**
+**As a** client application
+**I want to** retrieve channel information
+**So that** I can display channel details
 
 **Acceptance Criteria:**
-- [ ] GET `/api/v1/channels/{uuid}` endpoint exists
-- [ ] Returns channel data
-- [ ] Only returns channels belonging to authenticated client
-- [ ] Returns 404 for non-existent channel
-- [ ] Returns 404 for channel from different client
+- [x] GET `/api/v1/channels/{uuid}` endpoint exists
+- [x] Returns channel data
+- [x] Only returns channels belonging to authenticated client
+- [x] Returns 404 for non-existent channel
+- [x] Returns 404 for channel from different client
+
+**Test Cases:**
+- [x] Can retrieve channel information when authenticated
+- [x] Returns 404 for non-existent channel
+- [x] Returns 404 for channel from different client
+- [x] Requires authentication
+- [x] Requires public key header
+- [x] Validates origin domain
+- [x] Can retrieve custom channel
+- [x] Returns proper JSON structure
 
 ### Story 2.4: List Channels
 **As a** client application  

--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -171,4 +171,42 @@ class ChannelController extends Controller
             'total_count' => $result['total_count'],
         ]);
     }
+
+    /**
+     * Display channels for a specific customer.
+     *
+     * Retrieves all channels where the specified customer participates.
+     * Only returns channels belonging to the authenticated client.
+     *
+     * @param string $customerUuid Customer UUID to get channels for
+     * @return JsonResponse JSON response with customer's channels
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException When customer not found
+     * @throws \Illuminate\Auth\AuthenticationException When client is not authenticated
+     *
+     * @example
+     * GET /api/v1/channels/customer/customer_uuid_here
+     *
+     * Response (200):
+     * {
+     *     "object": "list",
+     *     "data": [...],
+     *     "has_more": false,
+     *     "total_count": 2
+     * }
+     */
+    public function getCustomerChannels(string $customerUuid): JsonResponse
+    {
+        $result = $this->channelService->getChannelsForCustomer(
+            auth('sanctum')->user(), // Client from middleware
+            $customerUuid
+        );
+
+        return response()->json([
+            'object' => 'list',
+            'data' => ChannelResource::collection($result['data']),
+            'has_more' => $result['has_more'],
+            'total_count' => $result['total_count'],
+        ]);
+    }
 }

--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\CreateChannelRequest;
+use App\Http\Resources\ChannelResource;
+use App\Services\ChannelServiceInterface;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Channel Controller
+ * 
+ * Handles HTTP requests for channel management operations.
+ * Provides RESTful endpoints for creating and managing channels.
+ * All operations are scoped to the authenticated client.
+ * 
+ * @package App\Http\Controllers
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ * 
+ * @example
+ * // Create a general channel
+ * POST /api/v1/channels
+ * {
+ *     "type": "general",
+ *     "customer_uuids": ["customer-uuid-1", "customer-uuid-2"]
+ * }
+ */
+class ChannelController extends Controller
+{
+    /**
+     * Create a new ChannelController instance.
+     * 
+     * Injects the channel service dependency for handling business logic.
+     * 
+     * @param ChannelServiceInterface $channelService Service for channel operations
+     */
+    public function __construct(
+        private ChannelServiceInterface $channelService
+    ) {}
+
+    /**
+     * Store a newly created channel in storage.
+     * 
+     * Creates a new channel for the authenticated client.
+     * Validates the request data and ensures proper customer validation.
+     * 
+     * @param CreateChannelRequest $request Validated request containing channel data
+     * @return JsonResponse JSON response with created channel data
+     * 
+     * @throws \Illuminate\Validation\ValidationException When validation fails
+     * @throws \Illuminate\Auth\AuthenticationException When client is not authenticated
+     * 
+     * @example
+     * POST /api/v1/channels
+     * {
+     *     "type": "general",
+     *     "customer_uuids": ["customer-uuid-1", "customer-uuid-2"]
+     * }
+     * 
+     * Response (201):
+     * {
+     *     "object": "channel",
+     *     "id": "channel_uuid",
+     *     "type": "general",
+     *     "name": "general",
+     *     "created": 1640995200
+     * }
+     */
+    public function store(CreateChannelRequest $request): JsonResponse
+    {
+        $channel = $this->channelService->create(
+            auth('sanctum')->user(), // Client from middleware
+            $request->validated()
+        );
+
+        return response()->json(new ChannelResource($channel), 201);
+    }
+}

--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -94,4 +94,39 @@ class ChannelController extends Controller
             throw $e;
         }
     }
+
+    /**
+     * Display the specified channel.
+     *
+     * Retrieves a single channel by UUID for the authenticated client.
+     * Only returns channels that belong to the authenticated client.
+     *
+     * @param string $uuid Channel UUID to retrieve
+     * @return JsonResponse JSON response with channel data
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException When channel not found
+     * @throws \Illuminate\Auth\AuthenticationException When client is not authenticated
+     *
+     * @example
+     * GET /api/v1/channels/channel_uuid_here
+     *
+     * Response (200):
+     * {
+     *     "object": "channel",
+     *     "id": "channel_uuid",
+     *     "type": "general",
+     *     "name": "general",
+     *     "created": 1640995200,
+     *     "livemode": false
+     * }
+     */
+    public function show(string $uuid): JsonResponse
+    {
+        $channel = $this->channelService->getByUuid(
+            auth('sanctum')->user(), // Client from middleware
+            $uuid
+        );
+
+        return response()->json(new ChannelResource($channel));
+    }
 }

--- a/app/Http/Requests/CreateChannelRequest.php
+++ b/app/Http/Requests/CreateChannelRequest.php
@@ -33,18 +33,25 @@ class CreateChannelRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      * 
-     * Validates channel type and customer UUIDs array.
+     * Validates channel type, customer UUIDs array, and custom channel name.
      * Ensures proper format and constraints for channel creation.
      * 
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string> Validation rules
      */
     public function rules(): array
     {
-        return [
+        $rules = [
             'type' => 'required|string|in:general,custom',
             'customer_uuids' => 'required|array|min:2|max:5',
             'customer_uuids.*' => 'required|string|uuid|exists:customers,uuid',
         ];
+
+        // Add name validation for custom channels
+        if ($this->input('type') === 'custom') {
+            $rules['name'] = 'required|string|max:255|unique:channels,name,NULL,id,client_id,' . auth('sanctum')->id();
+        }
+
+        return $rules;
     }
 
     /**
@@ -66,6 +73,10 @@ class CreateChannelRequest extends FormRequest
             'customer_uuids.*.required' => 'Customer UUID is required',
             'customer_uuids.*.uuid' => 'Customer UUID must be a valid UUID',
             'customer_uuids.*.exists' => 'One or more customers do not exist',
+            'name.required' => 'Channel name is required for custom channels',
+            'name.string' => 'Channel name must be a string',
+            'name.max' => 'Channel name cannot exceed 255 characters',
+            'name.unique' => 'A channel with this name already exists for your client',
         ];
     }
 }

--- a/app/Http/Requests/CreateChannelRequest.php
+++ b/app/Http/Requests/CreateChannelRequest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Create Channel Request
+ * 
+ * Validates incoming requests for creating new channels.
+ * Ensures proper channel type and customer UUID validation.
+ * 
+ * @package App\Http\Requests
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+class CreateChannelRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     * 
+     * Authorization is handled by the ClientAuthMiddleware.
+     * 
+     * @return bool Always returns true as authentication is handled by middleware
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     * 
+     * Validates channel type and customer UUIDs array.
+     * Ensures proper format and constraints for channel creation.
+     * 
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string> Validation rules
+     */
+    public function rules(): array
+    {
+        return [
+            'type' => 'required|string|in:general,custom',
+            'customer_uuids' => 'required|array|min:2|max:5',
+            'customer_uuids.*' => 'required|string|uuid|exists:customers,uuid',
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     * 
+     * Provides user-friendly error messages for validation failures.
+     * 
+     * @return array<string, string> Custom error messages
+     */
+    public function messages(): array
+    {
+        return [
+            'type.required' => 'Channel type is required',
+            'type.in' => 'Channel type must be either general or custom',
+            'customer_uuids.required' => 'At least two customers are required',
+            'customer_uuids.array' => 'Customer UUIDs must be provided as an array',
+            'customer_uuids.min' => 'At least two customers are required for a channel',
+            'customer_uuids.max' => 'Maximum of 5 customers allowed per channel',
+            'customer_uuids.*.required' => 'Customer UUID is required',
+            'customer_uuids.*.uuid' => 'Customer UUID must be a valid UUID',
+            'customer_uuids.*.exists' => 'One or more customers do not exist',
+        ];
+    }
+}

--- a/app/Http/Resources/ChannelResource.php
+++ b/app/Http/Resources/ChannelResource.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Channel Resource
+ * 
+ * Transforms Channel model data into consistent API responses.
+ * Follows Stripe-inspired API patterns for consistent formatting.
+ * 
+ * @package App\Http\Resources
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+class ChannelResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     * 
+     * Formats the channel data for API responses following Stripe patterns.
+     * Includes all necessary channel information with proper timestamps.
+     * 
+     * @param Request $request The HTTP request
+     * @return array<string, mixed> Formatted channel data
+     * 
+     * @example
+     * // Response format:
+     * {
+     *     "object": "channel",
+     *     "id": "channel_uuid",
+     *     "type": "general",
+     *     "name": "general",
+     *     "created": 1640995200,
+     *     "livemode": false
+     * }
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'object' => 'channel',
+            'id' => $this->uuid,
+            'type' => $this->type,
+            'name' => $this->name,
+            'created' => $this->created_at?->timestamp,
+            'livemode' => false, // TODO: Implement livemode logic
+        ];
+    }
+}

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Channel Model
+ * 
+ * Represents a communication channel between customers.
+ * Channels can be either "general" (direct messaging) or "custom" (topic-specific).
+ * Each channel belongs to a specific client and can have multiple customers.
+ * 
+ * @property int $id Auto-incrementing primary key
+ * @property string $uuid Unique identifier for public-facing operations
+ * @property int $client_id Foreign key to the client
+ * @property string $type Channel type (general or custom)
+ * @property string $name Channel name
+ * @property \Carbon\Carbon $created_at Creation timestamp
+ * @property \Carbon\Carbon $updated_at Last update timestamp
+ * @property \Carbon\Carbon|null $deleted_at Soft delete timestamp
+ * 
+ * @property-read \App\Models\Client $client The client that owns this channel
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Customer[] $customers Customers in this channel
+ * @property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Message[] $messages Messages in this channel
+ * 
+ * @method static \Illuminate\Database\Eloquent\Builder|Channel newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Channel newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Channel query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Channel withTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|Channel withoutTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|Channel onlyTrashed()
+ * 
+ * @example
+ * $channel = Channel::create([
+ *     'client_id' => 1,
+ *     'type' => 'general',
+ *     'name' => 'general'
+ * ]);
+ */
+class Channel extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'uuid',
+        'client_id',
+        'type',
+        'name',
+    ];
+
+    protected $casts = [
+        'type' => 'string',
+    ];
+
+    protected $keyType = 'int';
+    public $incrementing = true;
+
+    /**
+     * Get the route key for the model.
+     * 
+     * Returns the field name used for route model binding.
+     * Uses 'uuid' instead of the default 'id' for public-facing URLs.
+     * 
+     * @return string The route key name
+     * 
+     * @example
+     * // Route: /api/v1/channels/{channel}
+     * // Will bind using the 'uuid' field instead of 'id'
+     */
+    public function getRouteKeyName(): string
+    {
+        return 'uuid';
+    }
+
+    /**
+     * Boot the model.
+     * 
+     * Sets up model event listeners and automatic UUID generation.
+     * Automatically generates a UUID when creating a new channel if not provided.
+     * 
+     * @return void
+     * 
+     * @example
+     * $channel = new Channel(['type' => 'general', 'name' => 'general']);
+     * // UUID will be automatically generated on save
+     */
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (empty($model->uuid)) {
+                $model->uuid = (string) \Illuminate\Support\Str::uuid();
+            }
+        });
+    }
+
+    /**
+     * Get the client that owns the channel.
+     * 
+     * Establishes a belongs-to relationship with the Client model.
+     * Each channel belongs to exactly one client.
+     * 
+     * @return BelongsTo The relationship instance
+     * 
+     * @example
+     * $channel = Channel::find(1);
+     * $client = $channel->client; // Returns the associated Client model
+     */
+    public function client(): BelongsTo
+    {
+        return $this->belongsTo(Client::class);
+    }
+
+    /**
+     * Get the customers that belong to the channel.
+     * 
+     * Establishes a many-to-many relationship with the Customer model.
+     * Customers can belong to multiple channels through the 'channel_customer' pivot table.
+     * 
+     * @return BelongsToMany The relationship instance
+     * 
+     * @example
+     * $channel = Channel::find(1);
+     * $customers = $channel->customers; // Returns collection of associated customers
+     */
+    public function customers(): BelongsToMany
+    {
+        return $this->belongsToMany(Customer::class, 'channel_customer');
+    }
+
+    /**
+     * Get the messages in the channel.
+     * 
+     * Establishes a one-to-many relationship with the Message model.
+     * Returns all messages that belong to this channel.
+     * 
+     * @return HasMany The relationship instance
+     * 
+     * @example
+     * $channel = Channel::find(1);
+     * $messages = $channel->messages; // Returns collection of messages in this channel
+     */
+    public function messages(): HasMany
+    {
+        return $this->hasMany(Message::class);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Repositories\ChannelRepository;
+use App\Repositories\ChannelRepositoryInterface;
 use App\Repositories\CustomerRepository;
 use App\Repositories\CustomerRepositoryInterface;
+use App\Services\ChannelService;
+use App\Services\ChannelServiceInterface;
 use App\Services\CustomerService;
 use App\Services\CustomerServiceInterface;
 use Illuminate\Support\ServiceProvider;
@@ -19,9 +23,11 @@ class AppServiceProvider extends ServiceProvider
     {
         // Repository bindings
         $this->app->bind(CustomerRepositoryInterface::class, CustomerRepository::class);
+        $this->app->bind(ChannelRepositoryInterface::class, ChannelRepository::class);
         
         // Service bindings
         $this->app->bind(CustomerServiceInterface::class, CustomerService::class);
+        $this->app->bind(ChannelServiceInterface::class, ChannelService::class);
     }
 
     /**

--- a/app/Repositories/ChannelRepository.php
+++ b/app/Repositories/ChannelRepository.php
@@ -10,11 +10,11 @@ use Illuminate\Database\Eloquent\Collection;
 
 /**
  * Channel Repository
- * 
+ *
  * Handles data access operations for channel management.
  * Provides methods for creating, retrieving, and managing channels
- * with proper client isolation and business logic.
- * 
+ * with proper client isolation and customer relationships.
+ *
  * @package App\Repositories
  * @author Laravel Slime Talks
  * @version 1.0.0
@@ -23,13 +23,12 @@ class ChannelRepository implements ChannelRepositoryInterface
 {
     /**
      * Create a new channel.
-     * 
+     *
      * Creates a new channel record in the database with the provided data.
-     * The channel will be automatically associated with the client specified in the data.
-     * 
-     * @param array $data Channel data containing client_id, type, name, and customer IDs
+     *
+     * @param array $data Channel data containing client_id, type, and name
      * @return Channel Created channel instance
-     * 
+     *
      * @example
      * $channel = $repository->create([
      *     'client_id' => 1,
@@ -43,16 +42,76 @@ class ChannelRepository implements ChannelRepositoryInterface
     }
 
     /**
+     * Attach customers to a channel.
+     *
+     * Attaches a list of customers to the specified channel using the pivot table.
+     *
+     * @param Channel $channel The channel instance
+     * @param array $customerIds Array of customer IDs to attach
+     * @return void
+     *
+     * @example
+     * $repository->attachCustomers($channel, [1, 2]);
+     * // Attaches customers with IDs 1 and 2 to the channel
+     */
+    public function attachCustomers(Channel $channel, array $customerIds): void
+    {
+        $channel->customers()->attach($customerIds);
+    }
+
+    /**
+     * Check if a general channel exists between a set of customers for a client.
+     *
+     * Determines if a 'general' type channel already exists that includes exactly
+     * the given set of customer IDs for a specific client.
+     *
+     * @param array $customerIds Array of customer IDs
+     * @param Client $client The client
+     * @return bool True if a general channel exists, false otherwise
+     *
+     * @example
+     * $exists = $repository->generalChannelExistsBetweenCustomers([1, 2], $client);
+     * if ($exists) {
+     *     // General channel exists between customers 1 and 2 for this client
+     * }
+     */
+    public function generalChannelExistsBetweenCustomers(array $customerIds, Client $client): bool
+    {
+        // Sort customer IDs to ensure consistent comparison regardless of order
+        sort($customerIds);
+        $customerIdsJson = json_encode($customerIds);
+
+        // Find all general channels for the client
+        $generalChannels = Channel::where('client_id', $client->id)
+            ->where('type', 'general')
+            ->get();
+
+        foreach ($generalChannels as $channel) {
+            // Get customer IDs for the current channel and sort them
+            $channelCustomerIds = $channel->customers->pluck('id')->toArray();
+            sort($channelCustomerIds);
+            $channelCustomerIdsJson = json_encode($channelCustomerIds);
+
+            // Compare sorted customer ID arrays
+            if ($customerIdsJson === $channelCustomerIdsJson) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Find channel by UUID and client.
-     * 
+     *
      * Retrieves a channel by UUID, ensuring it belongs to the specified client.
      * This provides client isolation - clients can only access their own channels.
-     * 
+     *
      * @param string $uuid Channel UUID to find
      * @param Client $client Client instance to scope the search
      * @return Channel Channel instance
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException When channel not found or doesn't belong to client
-     * 
+     *
      * @example
      * $channel = $repository->findByUuidAndClient('channel-uuid-here', $client);
      * echo $channel->name; // "general"
@@ -65,66 +124,13 @@ class ChannelRepository implements ChannelRepositoryInterface
     }
 
     /**
-     * Check if a general channel exists between customers.
-     * 
-     * Verifies if a general channel already exists between the specified customers.
-     * This prevents duplicate general channels between the same customers.
-     * 
-     * @param array $customerIds Array of customer IDs to check
-     * @param Client $client Client instance to scope the search
-     * @return bool True if general channel exists between these customers
-     * 
-     * @example
-     * $exists = $repository->generalChannelExistsBetweenCustomers([1, 2], $client);
-     * if ($exists) {
-     *     // General channel already exists between these customers
-     * }
-     */
-    public function generalChannelExistsBetweenCustomers(array $customerIds, Client $client): bool
-    {
-        // Get all general channels for this client
-        $generalChannels = Channel::where('client_id', $client->id)
-            ->where('type', 'general')
-            ->get();
-
-        foreach ($generalChannels as $channel) {
-            $channelCustomerIds = $channel->customers()->pluck('customers.id')->toArray();
-            
-            // Check if the customer sets match (order doesn't matter)
-            if (count($customerIds) === count($channelCustomerIds) && 
-                empty(array_diff($customerIds, $channelCustomerIds))) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Attach customers to a channel.
-     * 
-     * Creates the many-to-many relationships between a channel and customers.
-     * 
-     * @param Channel $channel Channel instance
-     * @param array $customerIds Array of customer IDs to attach
-     * @return void
-     * 
-     * @example
-     * $repository->attachCustomers($channel, [1, 2, 3]);
-     */
-    public function attachCustomers(Channel $channel, array $customerIds): void
-    {
-        $channel->customers()->attach($customerIds);
-    }
-
-    /**
      * Get customers for a channel.
-     * 
+     *
      * Retrieves all customers that belong to the specified channel.
-     * 
+     *
      * @param Channel $channel Channel instance
      * @return Collection Collection of customers in the channel
-     * 
+     *
      * @example
      * $customers = $repository->getCustomers($channel);
      * echo $customers->count(); // Number of customers in the channel

--- a/app/Repositories/ChannelRepository.php
+++ b/app/Repositories/ChannelRepository.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Models\Channel;
+use App\Models\Client;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Channel Repository
+ * 
+ * Handles data access operations for channel management.
+ * Provides methods for creating, retrieving, and managing channels
+ * with proper client isolation and business logic.
+ * 
+ * @package App\Repositories
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+class ChannelRepository implements ChannelRepositoryInterface
+{
+    /**
+     * Create a new channel.
+     * 
+     * Creates a new channel record in the database with the provided data.
+     * The channel will be automatically associated with the client specified in the data.
+     * 
+     * @param array $data Channel data containing client_id, type, name, and customer IDs
+     * @return Channel Created channel instance
+     * 
+     * @example
+     * $channel = $repository->create([
+     *     'client_id' => 1,
+     *     'type' => 'general',
+     *     'name' => 'general'
+     * ]);
+     */
+    public function create(array $data): Channel
+    {
+        return Channel::create($data);
+    }
+
+    /**
+     * Find channel by UUID and client.
+     * 
+     * Retrieves a channel by UUID, ensuring it belongs to the specified client.
+     * This provides client isolation - clients can only access their own channels.
+     * 
+     * @param string $uuid Channel UUID to find
+     * @param Client $client Client instance to scope the search
+     * @return Channel Channel instance
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException When channel not found or doesn't belong to client
+     * 
+     * @example
+     * $channel = $repository->findByUuidAndClient('channel-uuid-here', $client);
+     * echo $channel->name; // "general"
+     */
+    public function findByUuidAndClient(string $uuid, Client $client): Channel
+    {
+        return Channel::where('uuid', $uuid)
+            ->where('client_id', $client->id)
+            ->firstOrFail();
+    }
+
+    /**
+     * Check if a general channel exists between customers.
+     * 
+     * Verifies if a general channel already exists between the specified customers.
+     * This prevents duplicate general channels between the same customers.
+     * 
+     * @param array $customerIds Array of customer IDs to check
+     * @param Client $client Client instance to scope the search
+     * @return bool True if general channel exists between these customers
+     * 
+     * @example
+     * $exists = $repository->generalChannelExistsBetweenCustomers([1, 2], $client);
+     * if ($exists) {
+     *     // General channel already exists between these customers
+     * }
+     */
+    public function generalChannelExistsBetweenCustomers(array $customerIds, Client $client): bool
+    {
+        // Get all general channels for this client
+        $generalChannels = Channel::where('client_id', $client->id)
+            ->where('type', 'general')
+            ->get();
+
+        foreach ($generalChannels as $channel) {
+            $channelCustomerIds = $channel->customers()->pluck('customers.id')->toArray();
+            
+            // Check if the customer sets match (order doesn't matter)
+            if (count($customerIds) === count($channelCustomerIds) && 
+                empty(array_diff($customerIds, $channelCustomerIds))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Attach customers to a channel.
+     * 
+     * Creates the many-to-many relationships between a channel and customers.
+     * 
+     * @param Channel $channel Channel instance
+     * @param array $customerIds Array of customer IDs to attach
+     * @return void
+     * 
+     * @example
+     * $repository->attachCustomers($channel, [1, 2, 3]);
+     */
+    public function attachCustomers(Channel $channel, array $customerIds): void
+    {
+        $channel->customers()->attach($customerIds);
+    }
+
+    /**
+     * Get customers for a channel.
+     * 
+     * Retrieves all customers that belong to the specified channel.
+     * 
+     * @param Channel $channel Channel instance
+     * @return Collection Collection of customers in the channel
+     * 
+     * @example
+     * $customers = $repository->getCustomers($channel);
+     * echo $customers->count(); // Number of customers in the channel
+     */
+    public function getCustomers(Channel $channel): Collection
+    {
+        return $channel->customers;
+    }
+}

--- a/app/Repositories/ChannelRepositoryInterface.php
+++ b/app/Repositories/ChannelRepositoryInterface.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Models\Channel;
+use App\Models\Client;
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Channel Repository Interface
+ * 
+ * Defines the contract for channel data access operations.
+ * Provides methods for creating, retrieving, and managing channels
+ * with proper client isolation and business logic.
+ * 
+ * @package App\Repositories
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+interface ChannelRepositoryInterface
+{
+    /**
+     * Create a new channel.
+     * 
+     * Creates a new channel record in the database with the provided data.
+     * The channel will be automatically associated with the client specified in the data.
+     * 
+     * @param array $data Channel data containing client_id, type, name, and customer IDs
+     * @return Channel Created channel instance
+     */
+    public function create(array $data): Channel;
+
+    /**
+     * Find channel by UUID and client.
+     * 
+     * Retrieves a channel by UUID, ensuring it belongs to the specified client.
+     * This provides client isolation - clients can only access their own channels.
+     * 
+     * @param string $uuid Channel UUID to find
+     * @param Client $client Client instance to scope the search
+     * @return Channel Channel instance
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException When channel not found or doesn't belong to client
+     */
+    public function findByUuidAndClient(string $uuid, Client $client): Channel;
+
+    /**
+     * Check if a general channel exists between customers.
+     * 
+     * Verifies if a general channel already exists between the specified customers.
+     * This prevents duplicate general channels between the same customers.
+     * 
+     * @param array $customerIds Array of customer IDs to check
+     * @param Client $client Client instance to scope the search
+     * @return bool True if general channel exists between these customers
+     */
+    public function generalChannelExistsBetweenCustomers(array $customerIds, Client $client): bool;
+
+    /**
+     * Attach customers to a channel.
+     * 
+     * Creates the many-to-many relationships between a channel and customers.
+     * 
+     * @param Channel $channel Channel instance
+     * @param array $customerIds Array of customer IDs to attach
+     * @return void
+     */
+    public function attachCustomers(Channel $channel, array $customerIds): void;
+
+    /**
+     * Get customers for a channel.
+     * 
+     * Retrieves all customers that belong to the specified channel.
+     * 
+     * @param Channel $channel Channel instance
+     * @return Collection Collection of customers in the channel
+     */
+    public function getCustomers(Channel $channel): Collection;
+}

--- a/app/Services/ChannelService.php
+++ b/app/Services/ChannelService.php
@@ -263,4 +263,26 @@ class ChannelService implements ChannelServiceInterface
     {
         return $this->channelRepository->findByUuidAndClient($uuid, $client);
     }
+
+    /**
+     * List channels for a client with pagination.
+     *
+     * Retrieves a paginated list of channels belonging to the specified client.
+     * Supports cursor-based pagination for efficient handling of large datasets.
+     *
+     * @param Client $client The client requesting channels
+     * @param int $limit Number of channels per page (default: 10)
+     * @param string|null $startingAfter UUID to start after for cursor pagination
+     * @return array{data: \Illuminate\Database\Eloquent\Collection, has_more: bool, total_count: int} Paginated results
+     *
+     * @example
+     * $result = $service->list($client, 20, 'previous-channel-uuid');
+     * $channels = $result['data']; // Collection of channels
+     * $hasMore = $result['has_more']; // Boolean indicating if more results exist
+     * $totalCount = $result['total_count']; // Total number of channels for this client
+     */
+    public function list(Client $client, int $limit = 10, ?string $startingAfter = null): array
+    {
+        return $this->channelRepository->paginateByClient($client, $limit, $startingAfter);
+    }
 }

--- a/app/Services/ChannelService.php
+++ b/app/Services/ChannelService.php
@@ -243,4 +243,24 @@ class ChannelService implements ChannelServiceInterface
             $this->channelRepository->attachCustomers($generalChannel, $customerIds);
         }
     }
+
+    /**
+     * Get channel by UUID for a specific client.
+     *
+     * Retrieves a channel by UUID, ensuring it belongs to the specified client.
+     * This provides client isolation - clients can only access their own channels.
+     *
+     * @param Client $client The client requesting the channel
+     * @param string $uuid Channel UUID to retrieve
+     * @return Channel Channel instance
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException When channel not found or doesn't belong to client
+     *
+     * @example
+     * $channel = $service->getByUuid($client, 'channel-uuid-here');
+     * echo $channel->name; // "general"
+     */
+    public function getByUuid(Client $client, string $uuid): Channel
+    {
+        return $this->channelRepository->findByUuidAndClient($uuid, $client);
+    }
 }

--- a/app/Services/ChannelService.php
+++ b/app/Services/ChannelService.php
@@ -285,4 +285,26 @@ class ChannelService implements ChannelServiceInterface
     {
         return $this->channelRepository->paginateByClient($client, $limit, $startingAfter);
     }
+
+    /**
+     * Get channels for a specific customer.
+     *
+     * Retrieves all channels where the specified customer participates.
+     * Only returns channels belonging to the specified client.
+     *
+     * @param Client $client The client requesting the channels
+     * @param string $customerUuid Customer UUID to get channels for
+     * @return array{data: \Illuminate\Database\Eloquent\Collection, has_more: bool, total_count: int} Customer's channels
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException When customer not found or doesn't belong to client
+     *
+     * @example
+     * $result = $service->getChannelsForCustomer($client, 'customer-uuid-here');
+     * $channels = $result['data']; // Collection of channels
+     * $hasMore = $result['has_more']; // Boolean indicating if more results exist
+     * $totalCount = $result['total_count']; // Total number of channels for this customer
+     */
+    public function getChannelsForCustomer(Client $client, string $customerUuid): array
+    {
+        return $this->channelRepository->getChannelsForCustomer($client, $customerUuid);
+    }
 }

--- a/app/Services/ChannelService.php
+++ b/app/Services/ChannelService.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Channel;
+use App\Models\Client;
+use App\Models\Customer;
+use App\Repositories\ChannelRepositoryInterface;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Channel Service
+ * 
+ * Handles business logic for channel management operations.
+ * Provides methods for creating channels with proper validation and client isolation.
+ * 
+ * @package App\Services
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ * 
+ * @example
+ * $service = app(ChannelService::class);
+ * $channel = $service->create($client, [
+ *     'type' => 'general',
+ *     'customer_uuids' => ['uuid1', 'uuid2']
+ * ]);
+ */
+class ChannelService implements ChannelServiceInterface
+{
+    /**
+     * Create a new ChannelService instance.
+     * 
+     * Injects the channel repository dependency for data access operations.
+     * 
+     * @param ChannelRepositoryInterface $channelRepository Repository for channel data operations
+     */
+    public function __construct(
+        private ChannelRepositoryInterface $channelRepository
+    ) {}
+
+    /**
+     * Create a new channel for a client.
+     * 
+     * Validates channel data, ensures customer validation,
+     * and creates a new channel record with proper relationships.
+     * 
+     * @param Client $client The client creating the channel
+     * @param array $data Channel data containing type and customer UUIDs
+     * @return Channel Created channel instance
+     * @throws ValidationException When validation fails
+     * 
+     * @example
+     * $channel = $service->create($client, [
+     *     'type' => 'general',
+     *     'customer_uuids' => ['customer-uuid-1', 'customer-uuid-2']
+     * ]);
+     */
+    public function create(Client $client, array $data): Channel
+    {
+        $this->validateChannelData($data);
+        
+        // Get customer IDs from UUIDs and validate they belong to the client
+        $customerIds = $this->getAndValidateCustomers($client, $data['customer_uuids']);
+        
+        // For general channels, check if channel already exists between these customers
+        if ($data['type'] === 'general') {
+            $this->ensureNoDuplicateGeneralChannel($customerIds, $client);
+        }
+        
+        // Create the channel
+        $channel = $this->channelRepository->create([
+            'client_id' => $client->id,
+            'type' => $data['type'],
+            'name' => $data['type'] === 'general' ? 'general' : $data['name'] ?? 'custom',
+        ]);
+        
+        // Attach customers to the channel
+        $this->channelRepository->attachCustomers($channel, $customerIds);
+        
+        return $channel;
+    }
+
+    /**
+     * Validate channel data.
+     * 
+     * Performs basic validation on channel data including required fields
+     * and type validation.
+     * 
+     * @param array $data Channel data to validate
+     * @return void
+     * @throws ValidationException When validation fails
+     * 
+     * @example
+     * $this->validateChannelData([
+     *     'type' => 'general',
+     *     'customer_uuids' => ['uuid1', 'uuid2']
+     * ]); // Throws ValidationException if invalid
+     */
+    private function validateChannelData(array $data): void
+    {
+        if (empty($data['type'])) {
+            $validator = Validator::make([], []);
+            $validator->errors()->add('type', 'Channel type is required');
+            throw new ValidationException($validator);
+        }
+        
+        if (!in_array($data['type'], ['general', 'custom'])) {
+            $validator = Validator::make([], []);
+            $validator->errors()->add('type', 'Channel type must be general or custom');
+            throw new ValidationException($validator);
+        }
+        
+        if (empty($data['customer_uuids']) || !is_array($data['customer_uuids'])) {
+            $validator = Validator::make([], []);
+            $validator->errors()->add('customer_uuids', 'Customer UUIDs are required and must be an array');
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * Get and validate customers for the channel.
+     * 
+     * Retrieves customer IDs from UUIDs and ensures they all belong to the client.
+     * 
+     * @param Client $client The client
+     * @param array $customerUuids Array of customer UUIDs
+     * @return array Array of customer IDs
+     * @throws ValidationException When customers don't exist or don't belong to client
+     * 
+     * @example
+     * $customerIds = $this->getAndValidateCustomers($client, ['uuid1', 'uuid2']);
+     * // Returns [1, 2] if both customers exist and belong to the client
+     */
+    private function getAndValidateCustomers(Client $client, array $customerUuids): array
+    {
+        $customers = Customer::whereIn('uuid', $customerUuids)
+            ->where('client_id', $client->id)
+            ->get();
+        
+        if ($customers->count() !== count($customerUuids)) {
+            $validator = Validator::make([], []);
+            $validator->errors()->add('customer_uuids', 'One or more customers do not exist or do not belong to this client');
+            throw new ValidationException($validator);
+        }
+        
+        return $customers->pluck('id')->toArray();
+    }
+
+    /**
+     * Ensure no duplicate general channel exists.
+     * 
+     * Checks if a general channel already exists between the specified customers.
+     * 
+     * @param array $customerIds Array of customer IDs
+     * @param Client $client The client
+     * @return void
+     * @throws ValidationException When duplicate general channel exists
+     * 
+     * @example
+     * $this->ensureNoDuplicateGeneralChannel([1, 2], $client);
+     * // Throws ValidationException if general channel already exists between customers 1 and 2
+     */
+    private function ensureNoDuplicateGeneralChannel(array $customerIds, Client $client): void
+    {
+        if ($this->channelRepository->generalChannelExistsBetweenCustomers($customerIds, $client)) {
+            $validator = Validator::make([], []);
+            $validator->errors()->add('customer_uuids', 'A general channel already exists between these customers');
+            throw new ValidationException($validator);
+        }
+    }
+}

--- a/app/Services/ChannelServiceInterface.php
+++ b/app/Services/ChannelServiceInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Channel;
+use App\Models\Client;
+
+/**
+ * Channel Service Interface
+ * 
+ * Defines the contract for channel business logic operations.
+ * Provides methods for creating and managing channels with proper validation
+ * and client isolation.
+ * 
+ * @package App\Services
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+interface ChannelServiceInterface
+{
+    /**
+     * Create a new channel for a client.
+     * 
+     * Validates channel data, ensures customer validation,
+     * and creates a new channel record with proper relationships.
+     * 
+     * @param Client $client The client creating the channel
+     * @param array $data Channel data containing type and customer UUIDs
+     * @return Channel Created channel instance
+     * @throws \Illuminate\Validation\ValidationException When validation fails
+     */
+    public function create(Client $client, array $data): Channel;
+}

--- a/database/factories/ChannelFactory.php
+++ b/database/factories/ChannelFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Channel>
+ */
+class ChannelFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'uuid' => \Illuminate\Support\Str::uuid(),
+            'type' => $this->faker->randomElement(['general', 'custom']),
+            'name' => $this->faker->words(2, true),
+        ];
+    }
+}

--- a/database/migrations/2025_10_08_033406_create_channels_table.php
+++ b/database/migrations/2025_10_08_033406_create_channels_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('channels', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->uuid('uuid')->unique();
+            $table->foreignId('client_id')->constrained()->onDelete('cascade');
+            $table->enum('type', ['general', 'custom']);
+            $table->string('name', 255);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('channels');
+    }
+};

--- a/database/migrations/2025_10_08_033419_create_channel_customer_table.php
+++ b/database/migrations/2025_10_08_033419_create_channel_customer_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('channel_customer', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+
+            $table->foreignId('channel_id')->constrained()->onDelete('cascade');
+            $table->foreignId('customer_id')->constrained()->onDelete('cascade');
+            
+            // Ensure unique combination of channel and customer
+            $table->unique(['channel_id', 'customer_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('channel_customer');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,5 +17,6 @@ Route::prefix('v1')->group(function () {
         Route::get('channels', [ChannelController::class, 'index']);
         Route::post('channels', [ChannelController::class, 'store']);
         Route::get('channels/{channel}', [ChannelController::class, 'show']);
+        Route::get('channels/customer/{customerUuid}', [ChannelController::class, 'getCustomerChannels']);
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ChannelController;
 use App\Http\Controllers\ClientController;
 use App\Http\Controllers\CustomerController;
 
@@ -13,5 +14,6 @@ Route::prefix('v1')->group(function () {
     Route::middleware('client.auth')->group(function () {
         Route::get('client/{client}', [ClientController::class, 'show']);
         Route::apiResource('customers', CustomerController::class);
+        Route::post('channels', [ChannelController::class, 'store']);
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,5 +15,6 @@ Route::prefix('v1')->group(function () {
         Route::get('client/{client}', [ClientController::class, 'show']);
         Route::apiResource('customers', CustomerController::class);
         Route::post('channels', [ChannelController::class, 'store']);
+        Route::get('channels/{channel}', [ChannelController::class, 'show']);
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,7 @@ Route::prefix('v1')->group(function () {
     Route::middleware('client.auth')->group(function () {
         Route::get('client/{client}', [ClientController::class, 'show']);
         Route::apiResource('customers', CustomerController::class);
+        Route::get('channels', [ChannelController::class, 'index']);
         Route::post('channels', [ChannelController::class, 'store']);
         Route::get('channels/{channel}', [ChannelController::class, 'show']);
     });

--- a/tests/Feature/ChannelTest.php
+++ b/tests/Feature/ChannelTest.php
@@ -408,7 +408,7 @@ describe('Channel API', function () {
             ])->postJson('/api/v1/channels', $channelData);
 
             $response->assertStatus(422)
-                ->assertJsonValidationErrors(['customer_uuids.1']);
+                ->assertJsonValidationErrors(['customer_uuids']);
         });
 
         it('requires authentication for custom channel', function () {

--- a/tests/Feature/ChannelTest.php
+++ b/tests/Feature/ChannelTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Channel;
+use App\Models\Client;
+use App\Models\Customer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+describe('Channel API', function () {
+    beforeEach(function () {
+        $this->client = Client::factory()->create();
+        $this->token = $this->client->createToken('test-token')->plainTextToken;
+    });
+
+    describe('Create Channel', function () {
+        it('can create a general channel with valid customers', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelData = [
+                'type' => 'general',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(201)
+                ->assertJsonStructure([
+                    'object',
+                    'id',
+                    'type',
+                    'name',
+                    'created',
+                    'livemode',
+                ])
+                ->assertJson([
+                    'object' => 'channel',
+                    'type' => 'general',
+                    'name' => 'general',
+                ]);
+
+            $this->assertDatabaseHas('channels', [
+                'client_id' => $this->client->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            // Verify customers are attached to the channel
+            $channel = Channel::where('client_id', $this->client->id)->first();
+            expect($channel->customers)->toHaveCount(2);
+            expect($channel->customers->pluck('id')->toArray())->toContain($customer1->id, $customer2->id);
+        });
+
+        it('rejects if customers do not exist', function () {
+            $nonExistentUuid = '00000000-0000-0000-0000-000000000000';
+
+            $channelData = [
+                'type' => 'general',
+                'customer_uuids' => [$nonExistentUuid, 'another-non-existent-uuid'],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['customer_uuids.0', 'customer_uuids.1']);
+        });
+
+        it('rejects if customers belong to different clients', function () {
+            $otherClient = Client::factory()->create();
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $otherClient->id]);
+
+            $channelData = [
+                'type' => 'general',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['customer_uuids']);
+        });
+
+        it('prevents duplicate general channels between same customers', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            // Create first channel
+            $channelData = [
+                'type' => 'general',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            // Try to create duplicate channel
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['customer_uuids']);
+        });
+
+        it('requires authentication', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelData = [
+                'type' => 'general',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(401);
+        });
+
+        it('requires public key header', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelData = [
+                'type' => 'general',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(401);
+        });
+
+        it('validates required fields', function () {
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', []);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['type', 'customer_uuids']);
+        });
+
+        it('validates channel type', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelData = [
+                'type' => 'invalid-type',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['type']);
+        });
+
+        it('validates customer_uuids array format', function () {
+            $channelData = [
+                'type' => 'general',
+                'customer_uuids' => 'not-an-array',
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['customer_uuids']);
+        });
+
+        it('validates minimum number of customers', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelData = [
+                'type' => 'general',
+                'customer_uuids' => [$customer1->uuid], // Only one customer
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['customer_uuids']);
+        });
+
+        it('validates maximum number of customers', function () {
+            $customers = Customer::factory()->count(10)->create(['client_id' => $this->client->id]);
+            $customerUuids = $customers->pluck('uuid')->toArray();
+
+            $channelData = [
+                'type' => 'general',
+                'customer_uuids' => $customerUuids, // Too many customers
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['customer_uuids']);
+        });
+    });
+});

--- a/tests/Feature/ChannelTest.php
+++ b/tests/Feature/ChannelTest.php
@@ -237,4 +237,338 @@ describe('Channel API', function () {
                 ->assertJsonValidationErrors(['customer_uuids']);
         });
     });
+
+    describe('Create Custom Channel', function () {
+        it('can create a custom channel with valid data', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelData = [
+                'type' => 'custom',
+                'name' => 'Project Discussion',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(201)
+                ->assertJsonStructure([
+                    'object',
+                    'id',
+                    'type',
+                    'name',
+                    'created',
+                    'livemode',
+                ])
+                ->assertJson([
+                    'object' => 'channel',
+                    'type' => 'custom',
+                    'name' => 'Project Discussion',
+                ]);
+
+            $this->assertDatabaseHas('channels', [
+                'client_id' => $this->client->id,
+                'type' => 'custom',
+                'name' => 'Project Discussion',
+            ]);
+
+            // Verify customers are attached to the channel
+            $channel = Channel::where('client_id', $this->client->id)
+                ->where('type', 'custom')
+                ->first();
+            expect($channel->customers)->toHaveCount(2);
+            expect($channel->customers->pluck('id')->toArray())->toContain($customer1->id, $customer2->id);
+        });
+
+        it('automatically creates general channel if it does not exist', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelData = [
+                'type' => 'custom',
+                'name' => 'Project Discussion',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(201);
+
+            // Verify both custom and general channels exist
+            $this->assertDatabaseHas('channels', [
+                'client_id' => $this->client->id,
+                'type' => 'custom',
+                'name' => 'Project Discussion',
+            ]);
+
+            $this->assertDatabaseHas('channels', [
+                'client_id' => $this->client->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            // Verify both channels have the same customers
+            $customChannel = Channel::where('client_id', $this->client->id)
+                ->where('type', 'custom')
+                ->first();
+            $generalChannel = Channel::where('client_id', $this->client->id)
+                ->where('type', 'general')
+                ->first();
+
+            expect($customChannel->customers->pluck('id')->toArray())
+                ->toEqual($generalChannel->customers->pluck('id')->toArray());
+        });
+
+        it('does not create duplicate general channel if it already exists', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            // First create a general channel
+            $generalChannelData = [
+                'type' => 'general',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $generalChannelData);
+
+            // Count existing general channels
+            $initialGeneralChannels = Channel::where('client_id', $this->client->id)
+                ->where('type', 'general')
+                ->count();
+
+            // Now create a custom channel
+            $customChannelData = [
+                'type' => 'custom',
+                'name' => 'Project Discussion',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $customChannelData);
+
+            $response->assertStatus(201);
+
+            // Verify no additional general channel was created
+            $finalGeneralChannels = Channel::where('client_id', $this->client->id)
+                ->where('type', 'general')
+                ->count();
+
+            expect($finalGeneralChannels)->toBe($initialGeneralChannels);
+        });
+
+        it('rejects if customers do not exist for custom channel', function () {
+            $nonExistentUuid = '00000000-0000-0000-0000-000000000000';
+
+            $channelData = [
+                'type' => 'custom',
+                'name' => 'Project Discussion',
+                'customer_uuids' => [$nonExistentUuid, 'another-non-existent-uuid'],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['customer_uuids.0', 'customer_uuids.1']);
+        });
+
+        it('rejects if customers belong to different clients for custom channel', function () {
+            $otherClient = Client::factory()->create();
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $otherClient->id]);
+
+            $channelData = [
+                'type' => 'custom',
+                'name' => 'Project Discussion',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['customer_uuids.1']);
+        });
+
+        it('requires authentication for custom channel', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelData = [
+                'type' => 'custom',
+                'name' => 'Project Discussion',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(401);
+        });
+
+        it('validates required name field for custom channel', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelData = [
+                'type' => 'custom',
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+                // Missing 'name' field
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['name']);
+        });
+
+        it('validates name field is not empty for custom channel', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelData = [
+                'type' => 'custom',
+                'name' => '', // Empty name
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['name']);
+        });
+
+        it('validates name field maximum length for custom channel', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelData = [
+                'type' => 'custom',
+                'name' => str_repeat('a', 256), // Too long name (over 255 chars)
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['name']);
+        });
+
+        it('allows same name for different clients', function () {
+            $otherClient = Client::factory()->create();
+            $otherToken = $otherClient->createToken('test-token')->plainTextToken;
+
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $otherCustomer1 = Customer::factory()->create(['client_id' => $otherClient->id]);
+            $otherCustomer2 = Customer::factory()->create(['client_id' => $otherClient->id]);
+
+            $channelName = 'Project Discussion';
+
+            // Create custom channel for first client
+            $channelData1 = [
+                'type' => 'custom',
+                'name' => $channelName,
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $response1 = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData1);
+
+            $response1->assertStatus(201);
+
+            // Create custom channel for second client with same name
+            $channelData2 = [
+                'type' => 'custom',
+                'name' => $channelName,
+                'customer_uuids' => [$otherCustomer1->uuid, $otherCustomer2->uuid],
+            ];
+
+            $response2 = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $otherToken,
+                'X-Public-Key' => $otherClient->public_key,
+                'Origin' => $otherClient->domain,
+            ])->postJson('/api/v1/channels', $channelData2);
+
+            $response2->assertStatus(201);
+
+            // Verify both channels exist with the same name
+            $this->assertDatabaseHas('channels', [
+                'client_id' => $this->client->id,
+                'type' => 'custom',
+                'name' => $channelName,
+            ]);
+
+            $this->assertDatabaseHas('channels', [
+                'client_id' => $otherClient->id,
+                'type' => 'custom',
+                'name' => $channelName,
+            ]);
+        });
+
+        it('prevents duplicate custom channels with same name for same client', function () {
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            $channelName = 'Project Discussion';
+
+            // Create first custom channel
+            $channelData = [
+                'type' => 'custom',
+                'name' => $channelName,
+                'customer_uuids' => [$customer1->uuid, $customer2->uuid],
+            ];
+
+            $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            // Try to create duplicate custom channel with same name
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/channels', $channelData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['name']);
+        });
+    });
 });


### PR DESCRIPTION
## Epic 2: Channel Management

### Story 2.1: Create General Channel
**As a** client application  
**I want to** create a general channel between two customers  
**So that** they can have direct messaging  

**Acceptance Criteria:**
- [x] POST `/api/v1/channels` endpoint exists
- [x] Creates general channel between two customers
- [x] Both customers must belong to same client
- [x] Channel gets unique UUID
- [x] Channel type is "general"
- [x] Channel name is "general"
- [x] Returns channel data with UUID

**Test Cases:**
- [x] Can create general channel with valid customers
- [x] Rejects if customers don't exist
- [x] Rejects if customers belong to different clients
- [x] Prevents duplicate general channels between same customers
- [x] Requires authentication

### Story 2.2: Create Custom Channel
**As a** client application  
**I want to** create a custom channel for specific topics  
**So that** customers can discuss specific subjects  

**Acceptance Criteria:**
- [x] POST `/api/v1/channels` endpoint exists
- [x] Creates custom channel with specified name
- [x] Channel type is "custom"
- [x] Channel name is provided by client
- [x] Automatically creates general channel if it doesn't exist
- [x] Both customers must belong to same client
- [ ] Returns channel data with UUID

**Test Cases:**
- [x] Can create custom channel with valid data
- [x] Automatically creates general channel
- [x] Rejects if customers don't exist
- [x] Rejects if customers belong to different clients
- [x] Requires authentication

### Story 2.3: Retrieve Channel ✅ **COMPLETED**
**As a** client application
**I want to** retrieve channel information
**So that** I can display channel details

**Acceptance Criteria:**
- [x] GET `/api/v1/channels/{uuid}` endpoint exists
- [x] Returns channel data
- [x] Only returns channels belonging to authenticated client
- [x] Returns 404 for non-existent channel
- [x] Returns 404 for channel from different client

**Test Cases:**
- [x] Can retrieve channel information when authenticated
- [x] Returns 404 for non-existent channel
- [x] Returns 404 for channel from different client
- [x] Requires authentication
- [x] Requires public key header
- [x] Validates origin domain
- [x] Can retrieve custom channel
- [x] Returns proper JSON structure

### Story 2.4: List Channels ✅ **COMPLETED**
**As a** client application  
**I want to** list all channels for my client  
**So that** I can manage conversations  

**Acceptance Criteria:**
- [x] GET `/api/v1/channels` endpoint exists
- [x] Returns paginated list of channels
- [x] Only returns channels for authenticated client
- [x] Supports pagination parameters
- [x] Returns total count

**Test Cases:**
- [x] Can list channels for authenticated client
- [x] Only returns channels for authenticated client
- [x] Supports pagination parameters
- [x] Supports cursor-based pagination with starting_after
- [x] Returns empty list when no channels exist
- [x] Requires authentication
- [x] Requires public key header
- [x] Validates origin domain
- [x] Returns proper JSON structure for each channel
- [x] Handles default pagination parameters

### Story 2.5: Get Customer Channels ✅ **COMPLETED**
**As a** client application  
**I want to** get all channels for a specific customer  
**So that** I can show their conversation list  

**Acceptance Criteria:**
- [x] GET `/api/v1/channels/customer/{customer_uuid}` endpoint exists
- [x] Returns channels where customer participates
- [x] Only returns channels for authenticated client
- [x] Returns 404 for non-existent customer
- [x] Returns 404 for customer from different client