### PR TITLE
Epic 3: Message Management

### DIFF
--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -248,18 +248,31 @@
 - [x] Returns proper JSON structure for each message
 - [x] Handles default pagination parameters
 
-### Story 3.3: Retrieve Customer Messages
+### Story 3.3: Retrieve Customer Messages ✅ **COMPLETED**
 **As a** client application  
 **I want to** retrieve all messages for a customer  
 **So that** I can show their message history  
 
 **Acceptance Criteria:**
-- [ ] GET `/api/v1/messages/customer/{customer_uuid}` endpoint exists
-- [ ] Returns messages from all customer's channels
-- [ ] Messages ordered by creation time (newest first)
-- [ ] Only returns messages for authenticated client
-- [ ] Supports pagination parameters
-- [ ] Returns total count
+- [x] GET `/api/v1/messages/customer/{customer_uuid}` endpoint exists
+- [x] Returns messages from all customer's channels
+- [x] Messages ordered by creation time (newest first)
+- [x] Only returns messages for authenticated client
+- [x] Supports pagination parameters
+- [x] Returns total count
+
+**Test Cases:**
+- [x] Can retrieve messages for a customer
+- [x] Returns empty list when customer has no messages
+- [x] Returns 404 for non-existent customer
+- [x] Returns 404 for customer from different client
+- [x] Supports pagination parameters
+- [x] Supports cursor-based pagination with starting_after
+- [x] Requires authentication
+- [x] Requires public key header
+- [x] Validates origin domain
+- [x] Returns proper JSON structure for each message
+- [x] Handles default pagination parameters
 
 ## Epic 4: Data Models & Migrations
 

--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -193,27 +193,34 @@
 
 ## Epic 3: Message Management
 
-### Story 3.1: Send Message
+### Story 3.1: Send Message ✅ **COMPLETED**
 **As a** client application  
 **I want to** send messages in channels  
 **So that** customers can communicate  
 
 **Acceptance Criteria:**
-- [ ] POST `/api/v1/messages` endpoint exists
-- [ ] Sends message to specified channel
-- [ ] Sender must be participant in channel
-- [ ] Message gets unique UUID
-- [ ] Supports different message types (text, image, file)
-- [ ] Returns message data with UUID
-- [ ] Timestamps message creation
+- [x] POST `/api/v1/messages` endpoint exists
+- [x] Sends message to specified channel
+- [x] Sender must be participant in channel
+- [x] Message gets unique UUID
+- [x] Supports different message types (text, image, file)
+- [x] Returns message data with UUID
+- [x] Timestamps message creation
 
 **Test Cases:**
-- [ ] Can send text message
-- [ ] Can send message with metadata
-- [ ] Rejects if sender not in channel
-- [ ] Rejects if channel doesn't exist
-- [ ] Rejects if channel belongs to different client
-- [ ] Requires authentication
+- [x] Can send text message
+- [x] Can send message with metadata
+- [x] Rejects if sender not in channel
+- [x] Rejects if channel doesn't exist
+- [x] Rejects if channel belongs to different client
+- [x] Requires authentication
+- [x] Requires public key header
+- [x] Validates origin domain
+- [x] Validates required fields
+- [x] Validates message type
+- [x] Validates content is not empty
+- [x] Supports different message types
+- [x] Returns proper JSON structure
 
 ### Story 3.2: Retrieve Channel Messages
 **As a** client application  

--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -222,18 +222,31 @@
 - [x] Supports different message types
 - [x] Returns proper JSON structure
 
-### Story 3.2: Retrieve Channel Messages
+### Story 3.2: Retrieve Channel Messages ✅ **COMPLETED**
 **As a** client application  
 **I want to** retrieve messages from a channel  
 **So that** I can display conversation history  
 
 **Acceptance Criteria:**
-- [ ] GET `/api/v1/messages/channel/{channel_uuid}` endpoint exists
-- [ ] Returns paginated list of messages
-- [ ] Messages ordered by creation time (oldest first)
-- [ ] Only returns messages from authenticated client's channels
-- [ ] Supports pagination parameters
-- [ ] Returns total count
+- [x] GET `/api/v1/messages/channel/{channel_uuid}` endpoint exists
+- [x] Returns paginated list of messages
+- [x] Messages ordered by creation time (oldest first)
+- [x] Only returns messages from authenticated client's channels
+- [x] Supports pagination parameters
+- [x] Returns total count
+
+**Test Cases:**
+- [x] Can retrieve messages from a channel
+- [x] Returns empty list when channel has no messages
+- [x] Returns 404 for non-existent channel
+- [x] Returns 404 for channel from different client
+- [x] Supports pagination parameters
+- [x] Supports cursor-based pagination with starting_after
+- [x] Requires authentication
+- [x] Requires public key header
+- [x] Validates origin domain
+- [x] Returns proper JSON structure for each message
+- [x] Handles default pagination parameters
 
 ### Story 3.3: Retrieve Customer Messages
 **As a** client application  

--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\CreateMessageRequest;
+use App\Http\Resources\MessageResource;
+use App\Services\MessageServiceInterface;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Message Controller
+ *
+ * Handles HTTP requests for message management.
+ * Provides endpoints for sending messages in channels.
+ *
+ * @package App\Http\Controllers
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+class MessageController extends Controller
+{
+    /**
+     * Create a new MessageController instance.
+     *
+     * @param MessageServiceInterface $messageService Message service
+     */
+    public function __construct(
+        private readonly MessageServiceInterface $messageService
+    ) {}
+
+    /**
+     * Send a message to a channel.
+     *
+     * Creates a new message in the specified channel.
+     * Validates that the sender is a participant in the channel.
+     *
+     * @param CreateMessageRequest $request The validated request
+     * @return JsonResponse The message response
+     *
+     * @throws \Illuminate\Validation\ValidationException If validation fails
+     */
+    public function store(CreateMessageRequest $request): JsonResponse
+    {
+        try {
+            $client = auth('sanctum')->user();
+            $message = $this->messageService->sendMessage($request->validated(), $client->id);
+
+            return response()->json(new MessageResource($message), 201);
+
+        } catch (ValidationException $e) {
+            // Re-throw validation exceptions to return proper 422 responses
+            throw $e;
+        } catch (\Exception $e) {
+            Log::error('Failed to send message', [
+                'error' => $e->getMessage(),
+                'request_data' => $request->all(),
+            ]);
+
+            return response()->json([
+                'error' => 'Failed to send message. Please try again.',
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Requests/CreateMessageRequest.php
+++ b/app/Http/Requests/CreateMessageRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Create Message Request
+ *
+ * Validates incoming message creation requests.
+ * Ensures all required fields are present and properly formatted.
+ *
+ * @package App\Http\Requests
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+class CreateMessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool True if authorized
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'channel_uuid' => 'required|string|exists:channels,uuid',
+            'sender_uuid' => 'required|string|exists:customers,uuid',
+            'type' => 'required|string|in:text,image,file',
+            'content' => 'required|string|min:1',
+            'metadata' => 'nullable|array',
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'channel_uuid.required' => 'Channel UUID is required',
+            'channel_uuid.exists' => 'Channel does not exist',
+            'sender_uuid.required' => 'Sender UUID is required',
+            'sender_uuid.exists' => 'Sender does not exist',
+            'type.required' => 'Message type is required',
+            'type.in' => 'Message type must be text, image, or file',
+            'content.required' => 'Message content is required',
+            'content.min' => 'Message content cannot be empty',
+        ];
+    }
+}

--- a/app/Http/Resources/MessageResource.php
+++ b/app/Http/Resources/MessageResource.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Message Resource
+ *
+ * Transforms Message model data into consistent API responses.
+ * Follows Stripe-inspired API patterns for consistent formatting.
+ *
+ * @package App\Http\Resources
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+class MessageResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * Formats the message data for API responses following Stripe patterns.
+     * Includes all necessary message information with proper timestamps.
+     *
+     * @param Request $request The HTTP request
+     * @return array<string, mixed> Formatted message data
+     *
+     * @example
+     * // Response format:
+     * {
+     *     "object": "message",
+     *     "id": "message_uuid",
+     *     "type": "text",
+     *     "content": "Hello world!",
+     *     "metadata": {"priority": "high"},
+     *     "created": 1640995200,
+     *     "livemode": false
+     * }
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'object' => 'message',
+            'id' => $this->uuid,
+            'type' => $this->type,
+            'content' => $this->content,
+            'metadata' => $this->metadata,
+            'created' => $this->created_at?->timestamp,
+            'livemode' => false, // TODO: Implement livemode logic
+        ];
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+/**
+ * Message Model
+ *
+ * Represents a message sent in a channel by a customer.
+ * Messages support different types (text, image, file) and can contain metadata.
+ * All messages are scoped to a specific client for data isolation.
+ *
+ * @package App\Models
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ *
+ * @property int $id
+ * @property string $uuid
+ * @property int $client_id
+ * @property int $channel_id
+ * @property int $sender_id
+ * @property string $type
+ * @property string $content
+ * @property array|null $metadata
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ *
+ * @property-read Client $client
+ * @property-read Channel $channel
+ * @property-read Customer $sender
+ */
+class Message extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'uuid',
+        'client_id',
+        'channel_id',
+        'sender_id',
+        'type',
+        'content',
+        'metadata',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'metadata' => 'array',
+    ];
+
+    /**
+     * Boot the model.
+     *
+     * Generates UUID for new messages automatically.
+     */
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (Message $message) {
+            if (empty($message->uuid)) {
+                $message->uuid = Str::uuid();
+            }
+        });
+    }
+
+    /**
+     * Get the client that owns the message.
+     *
+     * @return BelongsTo
+     */
+    public function client(): BelongsTo
+    {
+        return $this->belongsTo(Client::class);
+    }
+
+    /**
+     * Get the channel that the message belongs to.
+     *
+     * @return BelongsTo
+     */
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(Channel::class);
+    }
+
+    /**
+     * Get the customer that sent the message.
+     *
+     * @return BelongsTo
+     */
+    public function sender(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class, 'sender_id');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,10 +8,14 @@ use App\Repositories\ChannelRepository;
 use App\Repositories\ChannelRepositoryInterface;
 use App\Repositories\CustomerRepository;
 use App\Repositories\CustomerRepositoryInterface;
+use App\Repositories\MessageRepository;
+use App\Repositories\MessageRepositoryInterface;
 use App\Services\ChannelService;
 use App\Services\ChannelServiceInterface;
 use App\Services\CustomerService;
 use App\Services\CustomerServiceInterface;
+use App\Services\MessageService;
+use App\Services\MessageServiceInterface;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -24,10 +28,12 @@ class AppServiceProvider extends ServiceProvider
         // Repository bindings
         $this->app->bind(CustomerRepositoryInterface::class, CustomerRepository::class);
         $this->app->bind(ChannelRepositoryInterface::class, ChannelRepository::class);
+        $this->app->bind(MessageRepositoryInterface::class, MessageRepository::class);
         
         // Service bindings
         $this->app->bind(CustomerServiceInterface::class, CustomerService::class);
         $this->app->bind(ChannelServiceInterface::class, ChannelService::class);
+        $this->app->bind(MessageServiceInterface::class, MessageService::class);
     }
 
     /**

--- a/app/Repositories/MessageRepository.php
+++ b/app/Repositories/MessageRepository.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Models\Channel;
+use App\Models\Customer;
+use App\Models\Message;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Message Repository
+ *
+ * Handles all database operations for message management.
+ * Implements the MessageRepositoryInterface contract.
+ *
+ * @package App\Repositories
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+class MessageRepository implements MessageRepositoryInterface
+{
+    /**
+     * Create a new message.
+     *
+     * @param array<string, mixed> $data Message data
+     * @return Message The created message
+     */
+    public function create(array $data): Message
+    {
+        return Message::create($data);
+    }
+
+    /**
+     * Find a message by UUID and client.
+     *
+     * @param string $uuid Message UUID
+     * @param int $clientId Client ID
+     * @return Message|null The message or null if not found
+     */
+    public function findByUuidAndClient(string $uuid, int $clientId): ?Message
+    {
+        return Message::where('uuid', $uuid)
+            ->where('client_id', $clientId)
+            ->first();
+    }
+
+    /**
+     * Check if a customer is a participant in a channel.
+     *
+     * @param int $customerId Customer ID
+     * @param int $channelId Channel ID
+     * @return bool True if customer is in channel
+     */
+    public function isCustomerInChannel(int $customerId, int $channelId): bool
+    {
+        return \DB::table('channel_customer')
+            ->where('customer_id', $customerId)
+            ->where('channel_id', $channelId)
+            ->exists();
+    }
+
+    /**
+     * Find a channel by UUID and client.
+     *
+     * @param string $uuid Channel UUID
+     * @param int $clientId Client ID
+     * @return Channel|null The channel or null if not found
+     */
+    public function findChannelByUuidAndClient(string $uuid, int $clientId): ?Channel
+    {
+        return Channel::where('uuid', $uuid)
+            ->where('client_id', $clientId)
+            ->first();
+    }
+
+    /**
+     * Find a customer by UUID and client.
+     *
+     * @param string $uuid Customer UUID
+     * @param int $clientId Client ID
+     * @return Customer|null The customer or null if not found
+     */
+    public function findCustomerByUuidAndClient(string $uuid, int $clientId): ?Customer
+    {
+        return Customer::where('uuid', $uuid)
+            ->where('client_id', $clientId)
+            ->first();
+    }
+}

--- a/app/Repositories/MessageRepository.php
+++ b/app/Repositories/MessageRepository.php
@@ -88,4 +88,49 @@ class MessageRepository implements MessageRepositoryInterface
             ->where('client_id', $clientId)
             ->first();
     }
+
+    /**
+     * Get messages for a channel with pagination.
+     *
+     * @param int $channelId Channel ID
+     * @param int $clientId Client ID
+     * @param int $limit Number of messages per page
+     * @param string|null $startingAfter Message UUID to start after
+     * @return array{data: \Illuminate\Database\Eloquent\Collection, has_more: bool, total_count: int}
+     */
+    public function getMessagesForChannel(int $channelId, int $clientId, int $limit = 10, ?string $startingAfter = null): array
+    {
+        $query = Message::where('channel_id', $channelId)
+            ->where('client_id', $clientId)
+            ->orderBy('created_at', 'asc')
+            ->orderBy('id', 'asc');
+
+        if ($startingAfter) {
+            $startingMessage = Message::where('uuid', $startingAfter)->first();
+            if ($startingMessage) {
+                $query->where(function ($q) use ($startingMessage) {
+                    $q->where('created_at', '>', $startingMessage->created_at)
+                        ->orWhere(function ($subQ) use ($startingMessage) {
+                            $subQ->where('created_at', $startingMessage->created_at)
+                                ->where('id', '>', $startingMessage->id);
+                        });
+                });
+            }
+        }
+
+        $messages = $query->limit($limit + 1)->get();
+        $hasMore = $messages->count() > $limit;
+        
+        if ($hasMore) {
+            $messages->pop();
+        }
+
+        return [
+            'data' => $messages,
+            'has_more' => $hasMore,
+            'total_count' => Message::where('channel_id', $channelId)
+                ->where('client_id', $clientId)
+                ->count(),
+        ];
+    }
 }

--- a/app/Repositories/MessageRepositoryInterface.php
+++ b/app/Repositories/MessageRepositoryInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Models\Message;
+
+/**
+ * Message Repository Interface
+ *
+ * Defines the contract for message data access operations.
+ * Abstracts database interactions for message management.
+ *
+ * @package App\Repositories
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+interface MessageRepositoryInterface
+{
+    /**
+     * Create a new message.
+     *
+     * @param array<string, mixed> $data Message data
+     * @return Message The created message
+     */
+    public function create(array $data): Message;
+
+    /**
+     * Find a message by UUID and client.
+     *
+     * @param string $uuid Message UUID
+     * @param int $clientId Client ID
+     * @return Message|null The message or null if not found
+     */
+    public function findByUuidAndClient(string $uuid, int $clientId): ?Message;
+
+    /**
+     * Check if a customer is a participant in a channel.
+     *
+     * @param int $customerId Customer ID
+     * @param int $channelId Channel ID
+     * @return bool True if customer is in channel
+     */
+    public function isCustomerInChannel(int $customerId, int $channelId): bool;
+
+    /**
+     * Find a channel by UUID and client.
+     *
+     * @param string $uuid Channel UUID
+     * @param int $clientId Client ID
+     * @return \App\Models\Channel|null The channel or null if not found
+     */
+    public function findChannelByUuidAndClient(string $uuid, int $clientId): ?\App\Models\Channel;
+
+    /**
+     * Find a customer by UUID and client.
+     *
+     * @param string $uuid Customer UUID
+     * @param int $clientId Client ID
+     * @return \App\Models\Customer|null The customer or null if not found
+     */
+    public function findCustomerByUuidAndClient(string $uuid, int $clientId): ?\App\Models\Customer;
+}

--- a/app/Repositories/MessageRepositoryInterface.php
+++ b/app/Repositories/MessageRepositoryInterface.php
@@ -61,4 +61,15 @@ interface MessageRepositoryInterface
      * @return \App\Models\Customer|null The customer or null if not found
      */
     public function findCustomerByUuidAndClient(string $uuid, int $clientId): ?\App\Models\Customer;
+
+    /**
+     * Get messages for a channel with pagination.
+     *
+     * @param int $channelId Channel ID
+     * @param int $clientId Client ID
+     * @param int $limit Number of messages per page
+     * @param string|null $startingAfter Message UUID to start after
+     * @return array{data: \Illuminate\Database\Eloquent\Collection, has_more: bool, total_count: int}
+     */
+    public function getMessagesForChannel(int $channelId, int $clientId, int $limit = 10, ?string $startingAfter = null): array;
 }

--- a/app/Repositories/MessageRepositoryInterface.php
+++ b/app/Repositories/MessageRepositoryInterface.php
@@ -72,4 +72,15 @@ interface MessageRepositoryInterface
      * @return array{data: \Illuminate\Database\Eloquent\Collection, has_more: bool, total_count: int}
      */
     public function getMessagesForChannel(int $channelId, int $clientId, int $limit = 10, ?string $startingAfter = null): array;
+
+    /**
+     * Get messages for a customer with pagination.
+     *
+     * @param int $customerId Customer ID
+     * @param int $clientId Client ID
+     * @param int $limit Number of messages per page
+     * @param string|null $startingAfter Message UUID to start after
+     * @return array{data: \Illuminate\Database\Eloquent\Collection, has_more: bool, total_count: int}
+     */
+    public function getMessagesForCustomer(int $customerId, int $clientId, int $limit = 10, ?string $startingAfter = null): array;
 }

--- a/app/Services/MessageService.php
+++ b/app/Services/MessageService.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Message;
+use App\Repositories\MessageRepositoryInterface;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Message Service
+ *
+ * Handles business logic for message management.
+ * Implements the MessageServiceInterface contract.
+ *
+ * @package App\Services
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+class MessageService implements MessageServiceInterface
+{
+    /**
+     * Create a new MessageService instance.
+     *
+     * @param MessageRepositoryInterface $messageRepository Message repository
+     */
+    public function __construct(
+        private readonly MessageRepositoryInterface $messageRepository
+    ) {}
+
+    /**
+     * Send a message to a channel.
+     *
+     * Validates that the sender is a participant in the channel
+     * and that both channel and sender belong to the authenticated client.
+     *
+     * @param array<string, mixed> $data Message data
+     * @param int $clientId Client ID
+     * @return Message The created message
+     * @throws ValidationException If validation fails
+     */
+    public function sendMessage(array $data, int $clientId): Message
+    {
+        try {
+            // Find channel and validate it belongs to client
+            $channel = $this->messageRepository->findChannelByUuidAndClient(
+                $data['channel_uuid'],
+                $clientId
+            );
+
+            if (!$channel) {
+                Log::warning('Message send failed: Channel not found or does not belong to client', [
+                    'channel_uuid' => $data['channel_uuid'],
+                    'client_id' => $clientId,
+                ]);
+
+                throw ValidationException::withMessages([
+                    'channel_uuid' => ['Channel does not exist or does not belong to your client.'],
+                ]);
+            }
+
+            // Find sender and validate it belongs to client
+            $sender = $this->messageRepository->findCustomerByUuidAndClient(
+                $data['sender_uuid'],
+                $clientId
+            );
+
+            if (!$sender) {
+                Log::warning('Message send failed: Sender not found or does not belong to client', [
+                    'sender_uuid' => $data['sender_uuid'],
+                    'client_id' => $clientId,
+                ]);
+
+                throw ValidationException::withMessages([
+                    'sender_uuid' => ['Sender does not exist or does not belong to your client.'],
+                ]);
+            }
+
+            // Validate sender is participant in channel
+            if (!$this->messageRepository->isCustomerInChannel($sender->id, $channel->id)) {
+                Log::warning('Message send failed: Sender is not a participant in channel', [
+                    'sender_id' => $sender->id,
+                    'channel_id' => $channel->id,
+                ]);
+
+                throw ValidationException::withMessages([
+                    'sender_uuid' => ['Sender is not a participant in this channel.'],
+                ]);
+            }
+
+            // Create message
+            $messageData = [
+                'uuid' => \Illuminate\Support\Str::uuid(),
+                'client_id' => $clientId,
+                'channel_id' => $channel->id,
+                'sender_id' => $sender->id,
+                'type' => $data['type'],
+                'content' => $data['content'],
+                'metadata' => $data['metadata'] ?? null,
+            ];
+
+            $message = $this->messageRepository->create($messageData);
+
+            return $message;
+
+        } catch (ValidationException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            Log::error('Unexpected error sending message', [
+                'error' => $e->getMessage(),
+                'data' => $data,
+                'client_id' => $clientId,
+            ]);
+
+            throw ValidationException::withMessages([
+                'general' => ['An unexpected error occurred while sending the message.'],
+            ]);
+        }
+    }
+}

--- a/app/Services/MessageServiceInterface.php
+++ b/app/Services/MessageServiceInterface.php
@@ -27,4 +27,16 @@ interface MessageServiceInterface
      * @throws \Illuminate\Validation\ValidationException If validation fails
      */
     public function sendMessage(array $data, int $clientId): Message;
+
+    /**
+     * Get messages for a channel.
+     *
+     * @param string $channelUuid Channel UUID
+     * @param int $clientId Client ID
+     * @param int $limit Number of messages per page
+     * @param string|null $startingAfter Message UUID to start after
+     * @return array{data: \Illuminate\Database\Eloquent\Collection, has_more: bool, total_count: int}
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException If channel not found
+     */
+    public function getChannelMessages(string $channelUuid, int $clientId, int $limit = 10, ?string $startingAfter = null): array;
 }

--- a/app/Services/MessageServiceInterface.php
+++ b/app/Services/MessageServiceInterface.php
@@ -39,4 +39,16 @@ interface MessageServiceInterface
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException If channel not found
      */
     public function getChannelMessages(string $channelUuid, int $clientId, int $limit = 10, ?string $startingAfter = null): array;
+
+    /**
+     * Get messages for a customer.
+     *
+     * @param string $customerUuid Customer UUID
+     * @param int $clientId Client ID
+     * @param int $limit Number of messages per page
+     * @param string|null $startingAfter Message UUID to start after
+     * @return array{data: \Illuminate\Database\Eloquent\Collection, has_more: bool, total_count: int}
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException If customer not found
+     */
+    public function getCustomerMessages(string $customerUuid, int $clientId, int $limit = 10, ?string $startingAfter = null): array;
 }

--- a/app/Services/MessageServiceInterface.php
+++ b/app/Services/MessageServiceInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Message;
+
+/**
+ * Message Service Interface
+ *
+ * Defines the contract for message business logic operations.
+ * Abstracts business rules for message management.
+ *
+ * @package App\Services
+ * @author Laravel Slime Talks
+ * @version 1.0.0
+ */
+interface MessageServiceInterface
+{
+    /**
+     * Send a message to a channel.
+     *
+     * @param array<string, mixed> $data Message data
+     * @param int $clientId Client ID
+     * @return Message The created message
+     * @throws \Illuminate\Validation\ValidationException If validation fails
+     */
+    public function sendMessage(array $data, int $clientId): Message;
+}

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Message>
+ */
+class MessageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'uuid' => \Illuminate\Support\Str::uuid(),
+            'type' => 'text',
+            'content' => $this->faker->sentence(),
+            'metadata' => null,
+        ];
+    }
+}

--- a/database/migrations/2025_10_08_040832_create_messages_table.php
+++ b/database/migrations/2025_10_08_040832_create_messages_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('uuid')->unique();
+            $table->foreignId('client_id')->constrained()->onDelete('cascade');
+            $table->foreignId('channel_id')->constrained()->onDelete('cascade');
+            $table->foreignId('sender_id')->constrained('customers')->onDelete('cascade');
+            $table->string('type')->default('text'); // text, image, file, etc.
+            $table->text('content');
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ChannelController;
 use App\Http\Controllers\ClientController;
 use App\Http\Controllers\CustomerController;
+use App\Http\Controllers\MessageController;
 
 Route::get('/user', function (Request $request) {
     return $request->user();
@@ -18,5 +19,6 @@ Route::prefix('v1')->group(function () {
         Route::post('channels', [ChannelController::class, 'store']);
         Route::get('channels/{channel}', [ChannelController::class, 'show']);
         Route::get('channels/customer/{customerUuid}', [ChannelController::class, 'getCustomerChannels']);
+        Route::post('messages', [MessageController::class, 'store']);
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,5 +20,6 @@ Route::prefix('v1')->group(function () {
         Route::get('channels/{channel}', [ChannelController::class, 'show']);
         Route::get('channels/customer/{customerUuid}', [ChannelController::class, 'getCustomerChannels']);
         Route::post('messages', [MessageController::class, 'store']);
+        Route::get('messages/channel/{channelUuid}', [MessageController::class, 'getChannelMessages']);
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,5 +21,6 @@ Route::prefix('v1')->group(function () {
         Route::get('channels/customer/{customerUuid}', [ChannelController::class, 'getCustomerChannels']);
         Route::post('messages', [MessageController::class, 'store']);
         Route::get('messages/channel/{channelUuid}', [MessageController::class, 'getChannelMessages']);
+        Route::get('messages/customer/{customerUuid}', [MessageController::class, 'getCustomerMessages']);
     });
 });

--- a/tests/Feature/MessageTest.php
+++ b/tests/Feature/MessageTest.php
@@ -1,0 +1,385 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Client;
+use App\Models\Customer;
+use App\Models\Message;
+
+beforeEach(function () {
+    $this->client = Client::factory()->create([
+        'name' => 'Test Client',
+        'domain' => 'test.com',
+        'public_key' => 'test-public-key',
+    ]);
+
+    $this->token = $this->client->createToken('test-token')->plainTextToken;
+});
+
+describe('Message API', function () {
+    describe('Send Message', function () {
+        it('can send text message', function () {
+            // Create customers and channel
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+            
+            $channel = Channel::factory()->create([
+                'client_id' => $this->client->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            // Attach customers to channel
+            $channel->customers()->attach([$customer1->id, $customer2->id]);
+
+            $messageData = [
+                'channel_uuid' => $channel->uuid,
+                'sender_uuid' => $customer1->uuid,
+                'type' => 'text',
+                'content' => 'Hello, this is a test message!',
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/messages', $messageData);
+
+            $response->assertStatus(201)
+                ->assertJsonStructure([
+                    'object',
+                    'id',
+                    'type',
+                    'content',
+                    'metadata',
+                    'created',
+                    'livemode',
+                ])
+                ->assertJson([
+                    'object' => 'message',
+                    'type' => 'text',
+                    'content' => 'Hello, this is a test message!',
+                ]);
+
+            // Verify message was created in database
+            $this->assertDatabaseHas('messages', [
+                'client_id' => $this->client->id,
+                'channel_id' => $channel->id,
+                'sender_id' => $customer1->id,
+                'type' => 'text',
+                'content' => 'Hello, this is a test message!',
+            ]);
+
+            // Verify UUID was generated
+            $message = Message::where('content', 'Hello, this is a test message!')->first();
+            expect($message->uuid)->not->toBeNull();
+        });
+
+        it('can send message with metadata', function () {
+            // Create customers and channel
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+            
+            $channel = Channel::factory()->create([
+                'client_id' => $this->client->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            // Attach customers to channel
+            $channel->customers()->attach([$customer1->id, $customer2->id]);
+
+            $messageData = [
+                'channel_uuid' => $channel->uuid,
+                'sender_uuid' => $customer1->uuid,
+                'type' => 'text',
+                'content' => 'Message with metadata',
+                'metadata' => [
+                    'priority' => 'high',
+                    'tags' => ['important', 'urgent'],
+                ],
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/messages', $messageData);
+
+            $response->assertStatus(201)
+                ->assertJson([
+                    'object' => 'message',
+                    'type' => 'text',
+                    'content' => 'Message with metadata',
+                    'metadata' => [
+                        'priority' => 'high',
+                        'tags' => ['important', 'urgent'],
+                    ],
+                ]);
+
+            // Verify metadata was stored
+            $this->assertDatabaseHas('messages', [
+                'content' => 'Message with metadata',
+                'metadata' => json_encode([
+                    'priority' => 'high',
+                    'tags' => ['important', 'urgent'],
+                ]),
+            ]);
+        });
+
+        it('rejects if sender not in channel', function () {
+            // Create customers and channel
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer3 = Customer::factory()->create(['client_id' => $this->client->id]);
+            
+            $channel = Channel::factory()->create([
+                'client_id' => $this->client->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            // Attach only customer1 and customer2 to channel (not customer3)
+            $channel->customers()->attach([$customer1->id, $customer2->id]);
+
+            $messageData = [
+                'channel_uuid' => $channel->uuid,
+                'sender_uuid' => $customer3->uuid, // customer3 is not in channel
+                'type' => 'text',
+                'content' => 'This should fail',
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/messages', $messageData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['sender_uuid']);
+        });
+
+        it('rejects if channel does not exist', function () {
+            $customer = Customer::factory()->create(['client_id' => $this->client->id]);
+            $nonExistentChannelUuid = \Illuminate\Support\Str::uuid();
+
+            $messageData = [
+                'channel_uuid' => $nonExistentChannelUuid,
+                'sender_uuid' => $customer->uuid,
+                'type' => 'text',
+                'content' => 'This should fail',
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/messages', $messageData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['channel_uuid']);
+        });
+
+        it('rejects if channel belongs to different client', function () {
+            // Create customer for this client
+            $customer = Customer::factory()->create(['client_id' => $this->client->id]);
+
+            // Create another client and channel
+            $otherClient = Client::factory()->create([
+                'name' => 'Other Client',
+                'domain' => 'other.com',
+                'public_key' => 'other-public-key',
+            ]);
+
+            $otherChannel = Channel::factory()->create([
+                'client_id' => $otherClient->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            $messageData = [
+                'channel_uuid' => $otherChannel->uuid,
+                'sender_uuid' => $customer->uuid,
+                'type' => 'text',
+                'content' => 'This should fail',
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/messages', $messageData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['channel_uuid']);
+        });
+
+        it('requires authentication', function () {
+            $messageData = [
+                'channel_uuid' => 'some-uuid',
+                'sender_uuid' => 'some-uuid',
+                'type' => 'text',
+                'content' => 'This should fail',
+            ];
+
+            $response = $this->postJson('/api/v1/messages', $messageData);
+
+            $response->assertStatus(401)
+                ->assertJson(['error' => 'Unauthorized - Missing or invalid Authorization header']);
+        });
+
+        it('requires public key header', function () {
+            $messageData = [
+                'channel_uuid' => 'some-uuid',
+                'sender_uuid' => 'some-uuid',
+                'type' => 'text',
+                'content' => 'This should fail',
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/messages', $messageData);
+
+            $response->assertStatus(401)
+                ->assertJson(['error' => 'Unauthorized - Missing X-Public-Key header']);
+        });
+
+        it('validates origin domain', function () {
+            $messageData = [
+                'channel_uuid' => 'some-uuid',
+                'sender_uuid' => 'some-uuid',
+                'type' => 'text',
+                'content' => 'This should fail',
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => 'unauthorized.com',
+            ])->postJson('/api/v1/messages', $messageData);
+
+            $response->assertStatus(401)
+                ->assertJson(['error' => 'Unauthorized - Invalid origin domain']);
+        });
+
+        it('validates required fields', function () {
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/messages', []);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['channel_uuid', 'sender_uuid', 'type', 'content']);
+        });
+
+        it('validates message type', function () {
+            $customer = Customer::factory()->create(['client_id' => $this->client->id]);
+            $channel = Channel::factory()->create(['client_id' => $this->client->id]);
+            $channel->customers()->attach([$customer->id]);
+
+            $messageData = [
+                'channel_uuid' => $channel->uuid,
+                'sender_uuid' => $customer->uuid,
+                'type' => 'invalid_type',
+                'content' => 'This should fail',
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/messages', $messageData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['type']);
+        });
+
+        it('validates content is not empty', function () {
+            $customer = Customer::factory()->create(['client_id' => $this->client->id]);
+            $channel = Channel::factory()->create(['client_id' => $this->client->id]);
+            $channel->customers()->attach([$customer->id]);
+
+            $messageData = [
+                'channel_uuid' => $channel->uuid,
+                'sender_uuid' => $customer->uuid,
+                'type' => 'text',
+                'content' => '',
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/messages', $messageData);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['content']);
+        });
+
+        it('supports different message types', function () {
+            $customer = Customer::factory()->create(['client_id' => $this->client->id]);
+            $channel = Channel::factory()->create(['client_id' => $this->client->id]);
+            $channel->customers()->attach([$customer->id]);
+
+            $messageTypes = ['text', 'image', 'file'];
+
+            foreach ($messageTypes as $type) {
+                $messageData = [
+                    'channel_uuid' => $channel->uuid,
+                    'sender_uuid' => $customer->uuid,
+                    'type' => $type,
+                    'content' => "Test {$type} message",
+                ];
+
+                $response = $this->withHeaders([
+                    'Authorization' => 'Bearer ' . $this->token,
+                    'X-Public-Key' => $this->client->public_key,
+                    'Origin' => $this->client->domain,
+                ])->postJson('/api/v1/messages', $messageData);
+
+                $response->assertStatus(201)
+                    ->assertJson([
+                        'object' => 'message',
+                        'type' => $type,
+                        'content' => "Test {$type} message",
+                    ]);
+            }
+        });
+
+        it('returns proper JSON structure', function () {
+            $customer = Customer::factory()->create(['client_id' => $this->client->id]);
+            $channel = Channel::factory()->create(['client_id' => $this->client->id]);
+            $channel->customers()->attach([$customer->id]);
+
+            $messageData = [
+                'channel_uuid' => $channel->uuid,
+                'sender_uuid' => $customer->uuid,
+                'type' => 'text',
+                'content' => 'Test message',
+            ];
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->postJson('/api/v1/messages', $messageData);
+
+            $response->assertStatus(201)
+                ->assertJsonStructure([
+                    'object',
+                    'id',
+                    'type',
+                    'content',
+                    'metadata',
+                    'created',
+                    'livemode',
+                ])
+                ->assertJsonFragment([
+                    'object' => 'message',
+                    'type' => 'text',
+                    'content' => 'Test message',
+                ]);
+        });
+    });
+});

--- a/tests/Feature/MessageTest.php
+++ b/tests/Feature/MessageTest.php
@@ -729,4 +729,355 @@ describe('Message API', function () {
                 ]);
         });
     });
+
+    describe('Retrieve Customer Messages', function () {
+        it('can retrieve messages for a customer', function () {
+            // Create customers and channels
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+            
+            $channel1 = Channel::factory()->create([
+                'client_id' => $this->client->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            $channel2 = Channel::factory()->create([
+                'client_id' => $this->client->id,
+                'type' => 'custom',
+                'name' => 'support',
+            ]);
+
+            // Attach customers to channels
+            $channel1->customers()->attach([$customer1->id, $customer2->id]);
+            $channel2->customers()->attach([$customer1->id, $customer2->id]);
+
+            // Create messages in different channels
+            $message1 = Message::factory()->create([
+                'client_id' => $this->client->id,
+                'channel_id' => $channel1->id,
+                'sender_id' => $customer1->id,
+                'content' => 'Message in channel 1',
+            ]);
+
+            $message2 = Message::factory()->create([
+                'client_id' => $this->client->id,
+                'channel_id' => $channel2->id,
+                'sender_id' => $customer1->id,
+                'content' => 'Message in channel 2',
+            ]);
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->getJson("/api/v1/messages/customer/{$customer1->uuid}");
+
+            $response->assertStatus(200)
+                ->assertJsonStructure([
+                    'object',
+                    'data' => [
+                        '*' => [
+                            'object',
+                            'id',
+                            'type',
+                            'content',
+                            'metadata',
+                            'created',
+                            'livemode',
+                        ]
+                    ],
+                    'has_more',
+                    'total_count',
+                ])
+                ->assertJson([
+                    'object' => 'list',
+                    'has_more' => false,
+                    'total_count' => 2,
+                ]);
+
+            // Verify messages are ordered by creation time (newest first)
+            $messages = $response->json('data');
+            expect($messages)->toHaveCount(2);
+            // Messages should be ordered newest first
+            expect($messages[0]['content'])->toBe('Message in channel 2');
+            expect($messages[1]['content'])->toBe('Message in channel 1');
+        });
+
+        it('returns empty list when customer has no messages', function () {
+            $customer = Customer::factory()->create(['client_id' => $this->client->id]);
+            
+            $channel = Channel::factory()->create([
+                'client_id' => $this->client->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            // Attach customer to channel but don't create any messages
+            $channel->customers()->attach([$customer->id]);
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->getJson("/api/v1/messages/customer/{$customer->uuid}");
+
+            $response->assertStatus(200)
+                ->assertJson([
+                    'object' => 'list',
+                    'data' => [],
+                    'has_more' => false,
+                    'total_count' => 0,
+                ]);
+        });
+
+        it('returns 404 for non-existent customer', function () {
+            $nonExistentCustomerUuid = \Illuminate\Support\Str::uuid();
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->getJson("/api/v1/messages/customer/{$nonExistentCustomerUuid}");
+
+            $response->assertStatus(404);
+        });
+
+        it('returns 404 for customer from different client', function () {
+            // Create another client and customer
+            $otherClient = Client::factory()->create([
+                'name' => 'Other Client',
+                'domain' => 'other.com',
+                'public_key' => 'other-public-key',
+            ]);
+
+            $otherCustomer = Customer::factory()->create(['client_id' => $otherClient->id]);
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->getJson("/api/v1/messages/customer/{$otherCustomer->uuid}");
+
+            $response->assertStatus(404);
+        });
+
+        it('supports pagination parameters', function () {
+            // Create customers and channel
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+            
+            $channel = Channel::factory()->create([
+                'client_id' => $this->client->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            // Attach customers to channel
+            $channel->customers()->attach([$customer1->id, $customer2->id]);
+
+            // Create multiple messages
+            for ($i = 1; $i <= 5; $i++) {
+                Message::factory()->create([
+                    'client_id' => $this->client->id,
+                    'channel_id' => $channel->id,
+                    'sender_id' => $customer1->id,
+                    'content' => "Message {$i}",
+                ]);
+            }
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->getJson("/api/v1/messages/customer/{$customer1->uuid}?limit=3");
+
+            $response->assertStatus(200)
+                ->assertJson([
+                    'object' => 'list',
+                    'has_more' => true,
+                    'total_count' => 5,
+                ]);
+
+            $messages = $response->json('data');
+            expect($messages)->toHaveCount(3);
+        });
+
+        it('supports cursor-based pagination with starting_after', function () {
+            // Create customers and channel
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+            
+            $channel = Channel::factory()->create([
+                'client_id' => $this->client->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            // Attach customers to channel
+            $channel->customers()->attach([$customer1->id, $customer2->id]);
+
+            // Create messages with distinct timestamps
+            $message1 = Message::factory()->create([
+                'client_id' => $this->client->id,
+                'channel_id' => $channel->id,
+                'sender_id' => $customer1->id,
+                'content' => 'First message',
+            ]);
+            usleep(1000); // Ensure different timestamps
+
+            $message2 = Message::factory()->create([
+                'client_id' => $this->client->id,
+                'channel_id' => $channel->id,
+                'sender_id' => $customer1->id,
+                'content' => 'Second message',
+            ]);
+            usleep(1000);
+
+            $message3 = Message::factory()->create([
+                'client_id' => $this->client->id,
+                'channel_id' => $channel->id,
+                'sender_id' => $customer1->id,
+                'content' => 'Third message',
+            ]);
+
+            // Get first page
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->getJson("/api/v1/messages/customer/{$customer1->uuid}?limit=2");
+
+            $response->assertStatus(200);
+            $firstPageMessages = $response->json('data');
+            expect($firstPageMessages)->toHaveCount(2);
+
+            // Get second page using starting_after
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->getJson("/api/v1/messages/customer/{$customer1->uuid}?limit=2&starting_after={$firstPageMessages[1]['id']}");
+
+            $response->assertStatus(200);
+            $secondPageMessages = $response->json('data');
+            expect($secondPageMessages)->toHaveCount(1);
+            expect($secondPageMessages[0]['content'])->toBe('First message');
+        });
+
+        it('requires authentication', function () {
+            $customerUuid = \Illuminate\Support\Str::uuid();
+
+            $response = $this->getJson("/api/v1/messages/customer/{$customerUuid}");
+
+            $response->assertStatus(401)
+                ->assertJson(['error' => 'Unauthorized - Missing or invalid Authorization header']);
+        });
+
+        it('requires public key header', function () {
+            $customerUuid = \Illuminate\Support\Str::uuid();
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'Origin' => $this->client->domain,
+            ])->getJson("/api/v1/messages/customer/{$customerUuid}");
+
+            $response->assertStatus(401)
+                ->assertJson(['error' => 'Unauthorized - Missing X-Public-Key header']);
+        });
+
+        it('validates origin domain', function () {
+            $customerUuid = \Illuminate\Support\Str::uuid();
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => 'unauthorized.com',
+            ])->getJson("/api/v1/messages/customer/{$customerUuid}");
+
+            $response->assertStatus(401)
+                ->assertJson(['error' => 'Unauthorized - Invalid origin domain']);
+        });
+
+        it('returns proper JSON structure for each message', function () {
+            // Create customers and channel
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+            
+            $channel = Channel::factory()->create([
+                'client_id' => $this->client->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            // Attach customers to channel
+            $channel->customers()->attach([$customer1->id, $customer2->id]);
+
+            // Create a message
+            Message::factory()->create([
+                'client_id' => $this->client->id,
+                'channel_id' => $channel->id,
+                'sender_id' => $customer1->id,
+                'content' => 'Test message',
+            ]);
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->getJson("/api/v1/messages/customer/{$customer1->uuid}");
+
+            $response->assertStatus(200);
+            $messages = $response->json('data');
+            expect($messages)->toHaveCount(1);
+            
+            $message = $messages[0];
+            expect($message)->toHaveKeys([
+                'object',
+                'id',
+                'type',
+                'content',
+                'metadata',
+                'created',
+                'livemode',
+            ]);
+            expect($message['object'])->toBe('message');
+        });
+
+        it('handles default pagination parameters', function () {
+            // Create customers and channel
+            $customer1 = Customer::factory()->create(['client_id' => $this->client->id]);
+            $customer2 = Customer::factory()->create(['client_id' => $this->client->id]);
+            
+            $channel = Channel::factory()->create([
+                'client_id' => $this->client->id,
+                'type' => 'general',
+                'name' => 'general',
+            ]);
+
+            // Attach customers to channel
+            $channel->customers()->attach([$customer1->id, $customer2->id]);
+
+            // Create a message
+            Message::factory()->create([
+                'client_id' => $this->client->id,
+                'channel_id' => $channel->id,
+                'sender_id' => $customer1->id,
+                'content' => 'Test message',
+            ]);
+
+            $response = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+                'X-Public-Key' => $this->client->public_key,
+                'Origin' => $this->client->domain,
+            ])->getJson("/api/v1/messages/customer/{$customer1->uuid}");
+
+            $response->assertStatus(200)
+                ->assertJson([
+                    'object' => 'list',
+                    'has_more' => false,
+                    'total_count' => 1,
+                ]);
+        });
+    });
 });


### PR DESCRIPTION
### Story 3.1: Send Message ✅ **COMPLETED**
**As a** client application  
**I want to** send messages in channels  
**So that** customers can communicate  

**Acceptance Criteria:**
- [x] POST `/api/v1/messages` endpoint exists
- [x] Sends message to specified channel
- [x] Sender must be participant in channel
- [x] Message gets unique UUID
- [x] Supports different message types (text, image, file)
- [x] Returns message data with UUID
- [x] Timestamps message creation

**Test Cases:**
- [x] Can send text message
- [x] Can send message with metadata
- [x] Rejects if sender not in channel
- [x] Rejects if channel doesn't exist
- [x] Rejects if channel belongs to different client
- [x] Requires authentication
- [x] Requires public key header
- [x] Validates origin domain
- [x] Validates required fields
- [x] Validates message type
- [x] Validates content is not empty
- [x] Supports different message types
- [x] Returns proper JSON structure

### Story 3.2: Retrieve Channel Messages ✅ **COMPLETED**
**As a** client application  
**I want to** retrieve messages from a channel  
**So that** I can display conversation history  

**Acceptance Criteria:**
- [x] GET `/api/v1/messages/channel/{channel_uuid}` endpoint exists
- [x] Returns paginated list of messages
- [x] Messages ordered by creation time (oldest first)
- [x] Only returns messages from authenticated client's channels
- [x] Supports pagination parameters
- [x] Returns total count

**Test Cases:**
- [x] Can retrieve messages from a channel
- [x] Returns empty list when channel has no messages
- [x] Returns 404 for non-existent channel
- [x] Returns 404 for channel from different client
- [x] Supports pagination parameters
- [x] Supports cursor-based pagination with starting_after
- [x] Requires authentication
- [x] Requires public key header
- [x] Validates origin domain
- [x] Returns proper JSON structure for each message
- [x] Handles default pagination parameters

### Story 3.3: Retrieve Customer Messages ✅ **COMPLETED**
**As a** client application  
**I want to** retrieve all messages for a customer  
**So that** I can show their message history  

**Acceptance Criteria:**
- [x] GET `/api/v1/messages/customer/{customer_uuid}` endpoint exists
- [x] Returns messages from all customer's channels
- [x] Messages ordered by creation time (newest first)
- [x] Only returns messages for authenticated client
- [x] Supports pagination parameters
- [x] Returns total count

**Test Cases:**
- [x] Can retrieve messages for a customer
- [x] Returns empty list when customer has no messages
- [x] Returns 404 for non-existent customer
- [x] Returns 404 for customer from different client
- [x] Supports pagination parameters
- [x] Supports cursor-based pagination with starting_after
- [x] Requires authentication
- [x] Requires public key header
- [x] Validates origin domain
- [x] Returns proper JSON structure for each message
- [x] Handles default pagination parameters